### PR TITLE
K_12 Kwota netto - w tym świadczenie usług

### DIFF
--- a/sheet2jpk_vat/jpk_vat.py
+++ b/sheet2jpk_vat/jpk_vat.py
@@ -143,6 +143,7 @@ def Write(fo, nip_number, name, email, begin, end, sells, buys, version=0, sysna
 							xml.tns__K_20(Dec2Str(tax_value))
 						elif tax_percent == 'EU':
 							xml.tns__K_11(Dec2Str(net_value))
+							xml.tns__K_12(Dec2Str(net_value))
 						else:
 							raise ValueError('Unknown tax: "{}"'.format(tax_percent))
 


### PR DESCRIPTION
K_12 Kwota netto – w tym świadczenie usług, o których mowa w art. 100 ust. 1 pkt 4 ustawy (pole opcjonalne)
